### PR TITLE
brew-src: 4.1.11 -> 4.1.22

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1695643447,
-        "narHash": "sha256-N6+PVY+6K+xOzCFBudIuvooU1C5Y9qdP20ugyJ7NHZI=",
+        "lastModified": 1701986541,
+        "narHash": "sha256-0onun0B2aUn5qIpnjL05SWWkSvBEW/5C1CIvb6KzlQ4=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "a8519f78fb63f2f2266950bdd8141037da69f8bd",
+        "rev": "c32bd1c7cc0c3b1b914845bddfeda53f4d877a3f",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.1.13",
+        "ref": "4.1.25",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1701718818,
-        "narHash": "sha256-tEpz10RQle6G/ZVaM7MhWPYa8SVbrfugpbfklxKRJr0=",
+        "lastModified": 1700951817,
+        "narHash": "sha256-D5q1r00OrKKkwpmXXtI7HNZV4FFQLH8Qc+JrNfv84Gc=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "fc259153591a309e2b6fee6f971eb61b16a3b6c0",
+        "rev": "251a098fbf1c02ca95f53b4806e5b6da8d5e4a80",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.1.23",
+        "ref": "4.1.22",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1694443293,
-        "narHash": "sha256-wBjbF2RRFyD4lN7ie98VnggmNBwAPv/dg2U+w5mUyuM=",
+        "lastModified": 1704130657,
+        "narHash": "sha256-aTgrNh5clxiVc11sS+O9SvZxYWz2HXjMaAbrCZlIloA=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "4afb8e5602f3ecc9edf67a44257d8eceeaa8a108",
+        "rev": "705d2564ddfb9c915ee9425dd9ed408bfac61005",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.1.11",
+        "ref": "4.2.2",
         "repo": "brew",
         "type": "github"
       }
@@ -22,11 +22,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1688307440,
-        "narHash": "sha256-7PTjbN+/+b799YN7Tk2SS5Vh8A0L3gBo8hmB7Y0VXug=",
+        "lastModified": 1704277720,
+        "narHash": "sha256-meAKNgmh3goankLGWqqpw73pm9IvXjEENJloF0coskE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "b06bab83bdf285ea0ae3c8e145a081eb95959047",
+        "rev": "0dd382b70c351f528561f71a0a7df82c9d2be9a4",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1688049487,
-        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
+        "lastModified": 1704194953,
+        "narHash": "sha256-RtDKd8Mynhe5CFnVT8s0/0yqtWFMM9LmCzXv/YKxnq4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
+        "rev": "bd645e8668ec6612439a9ee7e71f7eac4099d4f6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1699726547,
-        "narHash": "sha256-0NuPp2l0hc+yk7+dCGhLVT0JFR+p8HDejba0YyIQREc=",
+        "lastModified": 1701718818,
+        "narHash": "sha256-tEpz10RQle6G/ZVaM7MhWPYa8SVbrfugpbfklxKRJr0=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "d3d51d3448966b5250b5c60110c945040054803d",
+        "rev": "fc259153591a309e2b6fee6f971eb61b16a3b6c0",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.1.20",
+        "ref": "4.1.23",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1704130657,
-        "narHash": "sha256-aTgrNh5clxiVc11sS+O9SvZxYWz2HXjMaAbrCZlIloA=",
+        "lastModified": 1695643447,
+        "narHash": "sha256-N6+PVY+6K+xOzCFBudIuvooU1C5Y9qdP20ugyJ7NHZI=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "705d2564ddfb9c915ee9425dd9ed408bfac61005",
+        "rev": "a8519f78fb63f2f2266950bdd8141037da69f8bd",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.2.2",
+        "ref": "4.1.13",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1699252524,
-        "narHash": "sha256-Y7kXjUyM1V+hQDjlRnyRBXJlctXEekFxl8XVVy+AGsk=",
+        "lastModified": 1699726547,
+        "narHash": "sha256-0NuPp2l0hc+yk7+dCGhLVT0JFR+p8HDejba0YyIQREc=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "7f745d04d90eaec76c8d5830d6ce6a0d7db888b3",
+        "rev": "d3d51d3448966b5250b5c60110c945040054803d",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.1.19",
+        "ref": "4.1.20",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1701986541,
-        "narHash": "sha256-0onun0B2aUn5qIpnjL05SWWkSvBEW/5C1CIvb6KzlQ4=",
+        "lastModified": 1699252524,
+        "narHash": "sha256-Y7kXjUyM1V+hQDjlRnyRBXJlctXEekFxl8XVVy+AGsk=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "c32bd1c7cc0c3b1b914845bddfeda53f4d877a3f",
+        "rev": "7f745d04d90eaec76c8d5830d6ce6a0d7db888b3",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.1.25",
+        "ref": "4.1.19",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nix-darwin.url = "github:LnL7/nix-darwin";
     flake-utils.url = "github:numtide/flake-utils";
     brew-src = {
-      url = "github:Homebrew/brew/4.2.2";
+      url = "github:Homebrew/brew/4.1.13";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -6,35 +6,44 @@
     nix-darwin.url = "github:LnL7/nix-darwin";
     flake-utils.url = "github:numtide/flake-utils";
     brew-src = {
-      url = "github:Homebrew/brew/4.1.11";
+      url = "github:Homebrew/brew/4.2.2";
       flake = false;
     };
   };
 
-  outputs = { self, nixpkgs, nix-darwin, flake-utils, brew-src, ... } @ inputs: let
+  outputs = {
+    self,
+    nixpkgs,
+    nix-darwin,
+    flake-utils,
+    brew-src,
+    ...
+  } @ inputs: let
     # System types to support.
-    supportedSystems = [ "x86_64-darwin" "aarch64-darwin" ];
-  in flake-utils.lib.eachSystem supportedSystems (system: let
-    pkgs = nixpkgs.legacyPackages.${system};
-  in {
-    packages = pkgs.callPackage ./pkgs {
-      inherit inputs;
-    };
-    devShell = pkgs.mkShell {
-      nativeBuildInputs = with pkgs; [
-      ];
-    };
-  }) // {
-    darwinModules = {
-      nix-homebrew = { lib, ... }: {
-        imports = [
-          ./modules
+    supportedSystems = ["x86_64-darwin" "aarch64-darwin"];
+  in
+    flake-utils.lib.eachSystem supportedSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      packages = pkgs.callPackage ./pkgs {
+        inherit inputs;
+      };
+      devShell = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [
         ];
-        nix-homebrew.package = lib.mkOptionDefault brew-src.outPath;
+      };
+    })
+    // {
+      darwinModules = {
+        nix-homebrew = {lib, ...}: {
+          imports = [
+            ./modules
+          ];
+          nix-homebrew.package = lib.mkOptionDefault brew-src.outPath;
+        };
+      };
+      darwinConfigurations = {
+        ci = import ./ci inputs;
       };
     };
-    darwinConfigurations = {
-      ci = import ./ci inputs;
-    };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nix-darwin.url = "github:LnL7/nix-darwin";
     flake-utils.url = "github:numtide/flake-utils";
     brew-src = {
-      url = "github:Homebrew/brew/4.1.19";
+      url = "github:Homebrew/brew/4.1.20";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nix-darwin.url = "github:LnL7/nix-darwin";
     flake-utils.url = "github:numtide/flake-utils";
     brew-src = {
-      url = "github:Homebrew/brew/4.1.20";
+      url = "github:Homebrew/brew/4.1.23";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nix-darwin.url = "github:LnL7/nix-darwin";
     flake-utils.url = "github:numtide/flake-utils";
     brew-src = {
-      url = "github:Homebrew/brew/4.1.23";
+      url = "github:Homebrew/brew/4.1.22";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nix-darwin.url = "github:LnL7/nix-darwin";
     flake-utils.url = "github:numtide/flake-utils";
     brew-src = {
-      url = "github:Homebrew/brew/4.1.25";
+      url = "github:Homebrew/brew/4.1.19";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nix-darwin.url = "github:LnL7/nix-darwin";
     flake-utils.url = "github:numtide/flake-utils";
     brew-src = {
-      url = "github:Homebrew/brew/4.1.13";
+      url = "github:Homebrew/brew/4.1.25";
       flake = false;
     };
   };


### PR DESCRIPTION
This PR updates homebrew to 4.1.22.

Now, as you can see from this PR, I tried updating to latest first, which did not work, and then tried a bunch of different version to find the last one that works. That version is 4.1.22.

In https://github.com/Homebrew/brew/pull/16268, they started using portable Ruby, which breaks the build for some reason. Need some guidance on how to fix this. Here is the error:

```
mkdir: /opt/homebrew/Library/Homebrew/vendor/portable-ruby: Permission denied
/opt/homebrew/Library/Homebrew/brew.sh: line 189: cd: /opt/homebrew/Library/Homebrew/vendor/portable-ruby: No such file or directory
Error: Failed to cd to /opt/homebrew/Library/Homebrew/vendor/portable-ruby!
Error: Failed to install Homebrew Portable Ruby (and your system version is too old)!
```