### PR TITLE
brew-src: 4.2.4 -> 4.2.16, embed HOMEBREW_VERSION

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1705326576,
-        "narHash": "sha256-9PvMgHgdbpb5vBO8fHCRufodR731ynzGMF9+68vKWck=",
+        "lastModified": 1711985568,
+        "narHash": "sha256-VLeP9HGQwfkiuHDp648PXGCkogr3ktYm0q9Yj+i0lGQ=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "1c612baa096c69f2fcb221c74e6f5b9979efdcee",
+        "rev": "bd1155be8f50998429a795c15a69c8fe75250510",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.2.4",
+        "ref": "4.2.16",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,9 @@
   outputs = { self, nixpkgs, nix-darwin, flake-utils, brew-src, ... } @ inputs: let
     # System types to support.
     supportedSystems = [ "x86_64-darwin" "aarch64-darwin" ];
+
+    flakeLock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    brewVersion = flakeLock.nodes.brew-src.original.ref;
   in flake-utils.lib.eachSystem supportedSystems (system: let
     pkgs = nixpkgs.legacyPackages.${system};
   in {
@@ -32,7 +35,10 @@
         imports = [
           ./modules
         ];
-        nix-homebrew.package = lib.mkOptionDefault brew-src.outPath;
+        nix-homebrew.package = lib.mkOptionDefault (brew-src // {
+          name = "brew-${brewVersion}";
+          version = brewVersion;
+        });
       };
     };
     darwinConfigurations = {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nix-darwin.url = "github:LnL7/nix-darwin";
     flake-utils.url = "github:numtide/flake-utils";
     brew-src = {
-      url = "github:Homebrew/brew/4.2.4";
+      url = "github:Homebrew/brew/4.2.16";
       flake = false;
     };
   };

--- a/modules/brew.tail.sh
+++ b/modules/brew.tail.sh
@@ -157,4 +157,4 @@ then
 fi
 unset VAR ENV_VAR_NAMES
 
-exec /usr/bin/env -i "${FILTERED_ENV[@]}" /bin/bash "${HOMEBREW_LIBRARY}/Homebrew/brew.sh" "$@"
+exec /usr/bin/env -i "${FILTERED_ENV[@]}" /bin/bash -p "${HOMEBREW_LIBRARY}/Homebrew/brew.sh" "$@"

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -287,7 +287,7 @@ let
 
   patchBrew = brew: let
     pinnedRuby = "${pkgs.ruby}/bin/ruby";
-  in pkgs.runCommandLocal "${brew.name or "brew"}-patched" {} ''
+  in pkgs.runCommandLocal "${brew.name or "brew"}-patched" {} (''
     cp -r "${brew}" "$out"
     chmod u+w "$out" "$out/Library/Homebrew/cmd"
 
@@ -301,7 +301,12 @@ let
       chmod u+w "$ruby_sh"
       echo -e "setup-ruby-path() { export HOMEBREW_RUBY_PATH=\"${pinnedRuby}\"; }" >>"$ruby_sh"
     fi
-  '';
+  '' + lib.optionalString (brew ? version) ''
+    # Embed version number instead of checking with git
+    brew_sh="$out/Library/Homebrew/brew.sh"
+    chmod u+w "$out/Library/Homebrew" "$brew_sh"
+    sed -i -e 's/^HOMEBREW_VERSION=.*/HOMEBREW_VERSION="${brew.version}"/g' "$brew_sh"
+  '');
 in {
   options = {
     nix-homebrew = {


### PR DESCRIPTION
`homebrew-bundle` now depends on `$HOMEBREW_VERSION`, which is set by `brew.sh` using the output of `git describe`. We don't have a git repo so let's embed the version directly.

Fixes #19.