### PR TITLE
Add option to install extra gem groups to brew

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -225,8 +225,10 @@ let
       initialize_prefix
     fi
 
-    # Synthetize $HOMEBREW_LIBRARY
+    # Synthesize $HOMEBREW_LIBRARY
     /bin/ln -shf "${brew}/Library/Homebrew" "$HOMEBREW_LIBRARY/Homebrew"
+    # Needed for `brew audit`, `brew style` to work:
+    /bin/ln -shf "${brew}/Library/.rubocop.yml" "$HOMEBREW_LIBRARY/.rubocop.yml"
     ${setupTaps prefix.taps}
 
     # Make a fake $HOMEBREW_REPOSITORY
@@ -235,6 +237,9 @@ let
     "''${CHOWN[@]}" "$NIX_HOMEBREW_UID:$NIX_HOMEBREW_GID" "$HOMEBREW_LIBRARY/.homebrew-is-managed-by-nix"
     "''${CHMOD[@]}" 775 "$HOMEBREW_LIBRARY/.homebrew-is-managed-by-nix/"{,.git}
     "''${TOUCH[@]}" "$HOMEBREW_LIBRARY/.homebrew-is-managed-by-nix/.git/HEAD"
+
+    # Needed for `brew style` (particularly, actionlint.yml):
+    /bin/ln -shf "${brew}/.github" "$HOMEBREW_LIBRARY/.homebrew-is-managed-by-nix/.github"
 
     # Link generated bin/brew
     BIN_BREW="$HOMEBREW_PREFIX/bin/brew"


### PR DESCRIPTION
Closes #35 

I ended up trying to implement the first option, because `brew install-bundler-gems` doesn't seem to have any way to specify a custom install directory for the gems (they are always expected to live in the vendored bundle directory).

This is kinda hacky, but at least seems to work for e.g. `brew livecheck`. Some other things like `brew style` might require more tweaking but this is a starting point to at least ensure the dependencies are installed.

With this configuration:
```nix
{
  nix-homebrew = {
    enable = true;
    enableRosetta = true;
    inherit user;

    bundlerGemGroups = [ "livecheck" "style"];
    # TODO: Declarative tap management
  };
}
```

I was able to run `brew livecheck`:
```console
$ brew tap homebrew/cask --force
==> Tapping homebrew/cask
Cloning into '/opt/homebrew/Library/Taps/homebrew/homebrew-cask'...
remote: Enumerating objects: 1073648, done.
remote: Counting objects: 100% (3871/3871), done.
remote: Compressing objects: 100% (1246/1246), done.
remote: Total 1073648 (delta 2842), reused 3629 (delta 2625), pack-reused 1069777 (from 1)
Receiving objects: 100% (1073648/1073648), 396.96 MiB | 15.93 MiB/s, done.
Resolving deltas: 100% (788997/788997), done.
Tapped 2 commands and 7041 casks (7,180 files, 436.1MB).
$ brew livecheck vlc
vlc: 3.0.21 ==> 3.0.21
```

Edit: and with the latest commit I can also `style` and `audit` my custom tap:
```console
$ brew audit --tap ian-h-chamberlain/dotfiles && brew style ian-h-chamberlain/dotfiles 
Inspecting 7 files
.......

7 files inspected, no offenses detected
```