### PR TITLE
enable shell integration

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -90,7 +90,7 @@ let
   # Our unified brew launcher script.
   #
   # We use `/bin/bash` (Bash 3.2 :/) instead of `${runtimeShell}`
-  # for compatibility with `arch -x86_64`. 
+  # for compatibility with `arch -x86_64`.
   brewLauncher = pkgs.writeScriptBin "brew" (''
     #!/bin/bash
     set -euo pipefail
@@ -437,6 +437,18 @@ in {
         type = types.bool;
         default = true;
       };
+
+      enableBashIntegration = lib.mkEnableOption "homebrew bash integration" // {
+        default = true;
+      };
+
+      enableFishIntegration = lib.mkEnableOption "homebrew fish integration" // {
+        default = true;
+      };
+
+      enableZshIntegration = lib.mkEnableOption "homebrew zsh integration" // {
+        default = true;
+      };
     };
   };
 
@@ -462,6 +474,19 @@ in {
         };
       };
     };
+
+    # Shell integrations
+    programs.bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
+      eval "$(brew shellenv 2>/dev/null || true)"
+    '';
+
+    programs.zsh.interactiveShellInit = lib.mkIf cfg.enableZshIntegration ''
+      eval "$(brew shellenv 2>/dev/null || true)"
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      brew shellenv 2>/dev/null | source || true
+    '';
 
     environment.systemPackages = [ brewLauncher ];
     system.activationScripts = {

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -438,6 +438,7 @@ in {
         default = true;
       };
 
+      # Shell integrations
       enableBashIntegration = lib.mkEnableOption "homebrew bash integration" // {
         default = true;
       };


### PR DESCRIPTION
fixes: #14 

i considered a 'shell' attrset that had the per-shell enabled stuff in that, but decided to start simpler. there's at least one example like this in nixpkgs for the 'foot' program.

https://github.com/NixOS/nixpkgs/blob/ee8bdf4f09fdb4809ff8f2202decbfd02450edc3/nixos/modules/programs/foot/default.nix#L83

i left the integration enabled by default for all 3 main shell programs. i figure it's more common to want the commands that not.

i also considered that the content of `brew shellenv` could easily be generated from the prefix and other info already within the module.

If you would prefer that route I can rework this, I think as-is does work fine though and it aligns with some homebrew instructions.

per homebrew docs, homebrew stuff is installed in front of the existing nix path which should prevent brew programs from failing in strange ways.

Example content of my brew shellenv command output:
```
export HOMEBREW_PREFIX="/opt/homebrew";
export HOMEBREW_CELLAR="/opt/homebrew/Cellar";
export HOMEBREW_REPOSITORY="/opt/homebrew/Library/.homebrew-is-managed-by-nix";
PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/Users/drewry.pope/.nix-profile/bin:/etc/profiles/per-user/drewry.pope/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin"; export PATH;
[ -z "${MANPATH-}" ] || export MANPATH=":${MANPATH#:}";
export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}";
```
Definitely could generate this ourselves if we wanted.

I'm not sure if manpath and infopath are correct for nix.

testing done: i opened each shell and saw that 'cowsay' was accessible.