### PR TITLE
document homebrew/nix-homebrew interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ If you haven't installed Homebrew before, use the following configuration:
       # (...)
       modules = [
         nix-homebrew.darwinModules.nix-homebrew
-        {
+        ({config, ...}: {
+          homebrew.taps = builtins.attrNames config.nix-homebrew.taps;
           nix-homebrew = {
             # Install Homebrew under the default prefix
             enable = true;
@@ -65,7 +66,7 @@ If you haven't installed Homebrew before, use the following configuration:
             # With mutableTaps disabled, taps can no longer be added imperatively with `brew tap`.
             mutableTaps = false;
           };
-        }
+        })
       ];
     };
   };
@@ -76,6 +77,8 @@ Once activated, a unified `brew` launcher will be created under `/run/current-sy
 Run `arch -x86_64 brew` to install X86-64 packages through Rosetta 2.
 
 With `nix-homebrew.mutableTaps = false`, taps can be removed by deleting the corresponding attribute in `nix-homebrew.taps` and activating the new configuration.
+
+Setting `homebrew.taps` to equal `nix-homebrew.taps` attribute names reduces configuration mismatches. 
 
 ### B. Existing Homebrew Installation
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ If you haven't installed Homebrew before, use the following configuration:
       # (...)
       modules = [
         nix-homebrew.darwinModules.nix-homebrew
-        ({config, ...}: {
-          homebrew.taps = builtins.attrNames config.nix-homebrew.taps;
+        {
           nix-homebrew = {
             # Install Homebrew under the default prefix
             enable = true;
@@ -66,6 +65,10 @@ If you haven't installed Homebrew before, use the following configuration:
             # With mutableTaps disabled, taps can no longer be added imperatively with `brew tap`.
             mutableTaps = false;
           };
+        }
+        # Optional: Align homebrew taps config with nix-homebrew
+        ({config, ...}: {
+          homebrew.taps = builtins.attrNames config.nix-homebrew.taps;
         })
       ];
     };


### PR DESCRIPTION
fixes: #5

or at least tries to. in order to fully fix it I think you would need another flag.

making the module automatically enable this if homebrew.taps is empty is a bit difficult. 

one could make an 'alignHomebrewConfig' mkEnable flag and then if a user sets that true then do the config change. but i'm not sure i've thought through all the interactions there, so for now here is a readme update that updates the instructions for a brand new user to homebrew.