### PR TITLE
Only set INSTALLING_HOMEBREW if homebrew module is enabled

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -502,8 +502,8 @@ in {
 
     # disable the install homebrew check
     # see https://github.com/LnL7/nix-darwin/pull/1178 and https://github.com/zhaofengli/nix-homebrew/issues/45
-    system.checks.text = lib.mkBefore ''
+    system.checks.text = lib.mkIf config.homebrew.enable (lib.mkBefore ''
       INSTALLING_HOMEBREW=1
-    '';
+    '');
   };
 }


### PR DESCRIPTION
Fallout of #47.

Fixes #48.