### PR TITLE
refactor: use git minimal

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -39,7 +39,7 @@ let
 
   # Sadly, we cannot replace coreutils since the GNU implementations
   # behave differently.
-  runtimePath = lib.makeBinPath [ pkgs.git ];
+  runtimePath = lib.makeBinPath [ pkgs.gitMinimal ];
 
   prefixType = types.submodule ({ name, ... }: {
     options = {


### PR DESCRIPTION
we should use git minimal here since it brings less deps (e.g. perl) and functions the same for the purpose of the script

Potential savings shown via nvd with a system that does not have git, or uses only gitMinimal:

```console
[R.]  #02  gzip                         1.13
[R.]  #03  perl5.40.0-Authen-SASL       2.1700
[R.]  #04  perl5.40.0-CGI               4.59
[R.]  #05  perl5.40.0-CGI-Fast          2.16
[R.]  #06  perl5.40.0-Clone             0.46
[R.]  #07  perl5.40.0-Digest-HMAC       1.04
[R.]  #08  perl5.40.0-Encode-Locale     1.05
[R.]  #09  perl5.40.0-FCGI              0.82
[R.]  #10  perl5.40.0-FCGI-ProcManager  0.28
[R.]  #11  perl5.40.0-File-Listing      6.16
[R.]  #12  perl5.40.0-HTML-Parser       3.81
[R.]  #13  perl5.40.0-HTML-TagCloud     0.38
[R.]  #14  perl5.40.0-HTML-Tagset       3.20
[R.]  #15  perl5.40.0-HTTP-CookieJar    0.014
[R.]  #16  perl5.40.0-HTTP-Cookies      6.10
[R.]  #17  perl5.40.0-HTTP-Date         6.06
[R.]  #18  perl5.40.0-HTTP-Message      6.45
[R.]  #19  perl5.40.0-HTTP-Negotiate    6.01
[R.]  #20  perl5.40.0-IO-HTML           1.004
[R.]  #21  perl5.40.0-IO-Socket-SSL     2.083
[R.]  #22  perl5.40.0-LWP-MediaTypes    6.04
[R.]  #23  perl5.40.0-Mozilla-CA        20230821
[R.]  #24  perl5.40.0-Net-HTTP          6.23
[R.]  #25  perl5.40.0-Net-SMTP-SSL      1.04
[R.]  #26  perl5.40.0-Net-SSLeay        1.92
[R.]  #27  perl5.40.0-TermReadKey       2.38
[R.]  #28  perl5.40.0-TimeDate          2.33
[R.]  #29  perl5.40.0-Try-Tiny          0.31
[R.]  #30  perl5.40.0-URI               5.21
[R.]  #31  perl5.40.0-WWW-RobotRules    6.02
[R.]  #32  perl5.40.0-libnet            3.15
[R.]  #33  perl5.40.0-libwww-perl       6.72
```
