### PR TITLE
fix: homebrew's own shell completion, man brew, and docs

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -231,6 +231,18 @@ let
     /bin/ln -shf "${brew}/Library/Homebrew" "$HOMEBREW_LIBRARY/Homebrew"
     ${setupTaps prefix.taps}
 
+    # Link brew docs
+    /bin/ln -shf "${brew}/docs" "$HOMEBREW_PREFIX/share/doc/homebrew"
+
+    # Link brew manpages
+    /bin/ln -shf "${brew}/manpages/README.md" "$HOMEBREW_PREFIX/share/man/man1/README.md"
+    /bin/ln -shf "${brew}/manpages/brew.1" "$HOMEBREW_PREFIX/share/man/man1/brew.1"
+    
+    # Link brew shell completions
+    /bin/ln -shf "${brew}/completions/bash/brew" "$HOMEBREW_PREFIX/etc/bash_completion.d/brew"
+    /bin/ln -shf "${brew}/completions/fish/brew.fish" "$HOMEBREW_PREFIX/share/fish/vendor_completions.d/brew.fish"
+    /bin/ln -shf "${brew}/completions/zsh/_brew" "$HOMEBREW_PREFIX/share/zsh/site-functions/_brew"
+
     # Make a fake $HOMEBREW_REPOSITORY
     rm -rf "$HOMEBREW_LIBRARY/.homebrew-is-managed-by-nix"
     "''${MKDIR[@]}" "$HOMEBREW_LIBRARY/.homebrew-is-managed-by-nix/.git"


### PR DESCRIPTION
Symlinking homebrew's own docs, manpages, and shell completions to the expected locations.

These files are discovered by running `brew doctor` and the files reported by the warning of "Warning: Broken symlinks were found"

Please note that this will be done for each prefix. brew completion ref: https://docs.brew.sh/Shell-Completion

Refs: #77