### PR TITLE
brew-src: 4.4.25 -> 4.5.0, upgrade to Ruby 3.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1742457334,
-        "narHash": "sha256-Gn7ruyb3NDFr+SsHBfA2NsJI8YkkWdECqLRj/xcjt+E=",
+        "lastModified": 1745912035,
+        "narHash": "sha256-qwLrR5iOcQMlwS0yrkcd0NRQvrmAXPOaiL6vxxzyIVA=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "f3bd91d3afe086824d24708230e1f0c7f943135a",
+        "rev": "3332d3331b56e0aff675d3816d8ebfe564075299",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.4.25",
+        "ref": "4.5.0",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -50,11 +50,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716330097,
-        "narHash": "sha256-8BO3B7e3BiyIDsaKA0tY8O88rClYRTjvAp66y+VBUeU=",
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5710852ba686cc1fd0d3b8e22b3117d43ba374c2",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nix-darwin.url = "github:LnL7/nix-darwin";
     brew-src = {
-      url = "github:Homebrew/brew/4.4.25";
+      url = "github:Homebrew/brew/4.5.0";
       flake = false;
     };
   };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -35,7 +35,7 @@ let
   tools = pkgs.callPackage ../pkgs { };
 
   brew = if cfg.patchBrew then patchBrew cfg.package else cfg.package;
-  ruby = pkgs.ruby_3_3;
+  ruby = pkgs.ruby_3_4;
 
   # Sadly, we cannot replace coreutils since the GNU implementations
   # behave differently.


### PR DESCRIPTION
As of recent release (I think [Homebrew 4.5.0](https://github.com/Homebrew/brew/releases/tag/4.5.0)), the minimum required Ruby version for Homebrew is 3.4. I've changed the Nix package from `pkgs.ruby_3_3` to `pkgs.ruby_3_4`, which currently installs Ruby 3.4.3 on the unstable and 24.11 channels.

Fixes zhaofengli/nix-homebrew#81