### PR TITLE
Drop 24.11 support

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -30,13 +30,6 @@ let
   # tap, it means it's managed by us.
   nixMarker = ".managed_by_nix_darwin";
 
-  # nix-darwin is migrating away from user activation in
-  # <https://github.com/LnL7/nix-darwin/pull/1341>.
-  # Before this PR, nix-darwin's homebrew activation was run as part
-  # of user activation (system.activationScripts.userScript) which is
-  # removed.
-  hasSystemWideActivation = options.system ? primaryUser;
-
   cfg = config.nix-homebrew;
 
   tools = pkgs.callPackage ../pkgs { };
@@ -471,6 +464,12 @@ in {
         assertion = cfg.enableRosetta -> pkgs.stdenv.hostPlatform.isAarch64;
         message = "nix-homebrew.enableRosetta is set to true but this isn't an Apple Silicon Mac";
       }
+      {
+        # nix-darwin has migrated away from user activation in
+        # <https://github.com/LnL7/nix-darwin/pull/1341>.
+        assertion = options.system ? primaryUser;
+        message = "Please update your nix-darwin version to use system-wide activation";
+      }
     ];
 
     nix-homebrew = {
@@ -508,12 +507,9 @@ in {
       homebrew.text = lib.mkBefore ''
         ${config.system.activationScripts.setup-homebrew.text}
       '';
-      setup-homebrew.text = if hasSystemWideActivation then ''
+      setup-homebrew.text = ''
         >&2 echo "setting up Homebrew prefixes..."
         ${setupHomebrew}
-      '' else ''
-        >&2 echo "setting up Homebrew prefixes (user activation)..."
-        sudo ${setupHomebrew}
       '';
     };
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -139,13 +139,16 @@ let
     '' + (lib.optionalString (cfg.extraEnv != {})
             (lib.concatLines (lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") cfg.extraEnv)))
        + (builtins.readFile ./brew.tail.sh));
-  in pkgs.substituteAll {
+  in pkgs.replaceVarsWith {
     name = "brew";
     src = template;
     isExecutable = true;
 
-    inherit runtimePath;
-    inherit (prefix) prefix library;
+    replacements = {
+      out = placeholder "out";
+      inherit runtimePath;
+      inherit (prefix) prefix library;
+    };
   };
 
   setupHomebrew = let

--- a/pkgs/nuke-homebrew-repository/default.nix
+++ b/pkgs/nuke-homebrew-repository/default.nix
@@ -1,6 +1,6 @@
 { lib
 , pkgs
-, substituteAll
+, replaceVarsWith
 , runtimeShell
 , coreutils
 , findutils
@@ -13,13 +13,15 @@
 }:
 
 let
-  script = substituteAll {
+  script = replaceVarsWith {
     name = "nuke-homebrew-repository";
     src = ./nuke-homebrew-repository.sh.in;
     isExecutable = true;
 
-    inherit runtimeShell;
-    path = lib.makeBinPath [ coreutils findutils gnugrep gnused gitMinimal ];
+    replacements = {
+      inherit runtimeShell;
+      path = lib.makeBinPath [ coreutils findutils gnugrep gnused gitMinimal ];
+    };
   };
 
   test-nuke =


### PR DESCRIPTION
25.05 has been [released](https://nixos.org/blog/announcements/2025/nixos-2505) and it's time to upgrade. Going forward, I think a reasonable policy is to support both unstable and the current stable version.

Reapplies #86. Fixes #83.