### PR TITLE
Don't patch shebang of prefix-specific brew launcher

### DIFF
--- a/ci/tests.nix
+++ b/ci/tests.nix
@@ -70,7 +70,7 @@ let
 in
 {
   migrate = makeTest (
-    { pkgs, ... }:
+    { pkgs, config, ... }:
     {
       imports = [
         (self + "/examples/migrate.nix")
@@ -95,6 +95,13 @@ in
 
         >&2 echo "Checking that we can still use the tap we added imperatively"
         brew install koekeishiya/formulae/yabai
+      '' + lib.optionalString config.nix-homebrew.enableRosetta ''
+        >&2 echo "Checking we can execute the Intel brew with arch -x86_64"
+        arch -x86_64 /usr/local/bin/brew config | grep "HOMEBREW_PREFIX: /usr/local"
+
+        >&2 echo "Checking that the unified brew launcher selects the correct prefix"
+        arch -arm64 brew config | grep "HOMEBREW_PREFIX: /opt/homebrew"
+        arch -x86_64 brew config | grep "HOMEBREW_PREFIX: /usr/local"
       '';
     }
   );

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -137,6 +137,10 @@ let
     src = template;
     isExecutable = true;
 
+    # Must retain #!/bin/bash, otherwise `arch -x86_64 /usr/local/bin/brew`
+    # on Apple Silicon will not work.
+    dontPatchShebangs = true;
+
     replacements = {
       out = placeholder "out";
       inherit runtimePath;


### PR DESCRIPTION
#94 uncovers an instance of https://github.com/NixOS/nixpkgs/issues/343576 when sandboxing is enabled. However, in this specific case the `#!/bin/bash` shebang is intentional so the script can be executed with `arch -x86_64`. The system version of bash is also what the upstream `brew` expects, as old and annoying as it is.

```console
$ head -1 /usr/local/bin/brew
/nix/store/8ivrpmp3arvxbr6imdwm2d28q9cjsqvi-bash-5.2p37/bin/bash
$ arch -x86_64 /usr/local/bin/brew install libarchive
arch: posix_spawnp: /usr/local/bin/brew: Bad CPU type in executable
$ /usr/local/bin/brew install libarchive
Error: Cannot install in Homebrew on ARM processor in Intel default prefix (/usr/local)!
Please create a new installation in /opt/homebrew using one of the
"Alternative Installs" from:
  https://docs.brew.sh/Installation
You can migrate your previously installed formula list with:
  brew bundle dump
```

The unified brew launcher works fine, but we want to support running the prefix-specific `brew` directly.

Fixes #94.