### PR TITLE
brew-src: 4.5.4 -> 4.5.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1748658199,
-        "narHash": "sha256-xmI9Bk8zDWgmvJlPpeHZk9yHCZPG5uxZH9VmdEdWCkU=",
+        "lastModified": 1749511373,
+        "narHash": "sha256-7u1TdHQaUCzzgf/n8T3bQosuYXyNBEPU/3WQQqozE5o=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "54c8b127ea2263fbbaf1354e3d8d86025e387ea6",
+        "rev": "7b4ef99fed96966269ee35994407fa4c06097a4d",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.5.4",
+        "ref": "4.5.6",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/4.5.4";
+      url = "github:Homebrew/brew/4.5.6";
       flake = false;
     };
   };

--- a/modules/brew.tail.sh
+++ b/modules/brew.tail.sh
@@ -89,8 +89,8 @@ MANPAGE_VARS=(
 )
 for VAR in "${MANPAGE_VARS[@]}"
 do
-  # Skip if variable value is empty.
-  [[ -z "${!VAR:-}" ]] && continue
+  # Skip if variable value is empty or set to 0.
+  [[ -z "${!VAR:-}" || "${!VAR:-}" = "0" ]] && continue
 
   VAR_NEW="HOMEBREW_${VAR}"
   # Skip if existing HOMEBREW_* variable is set.


### PR DESCRIPTION
Diff: https://github.com/Homebrew/brew/compare/4.5.4...4.5.6

brew 4.5.6 adds initial support for MacOS 26. I just upgraded to the Developer beta and brew seems to work fine. 