### PR TITLE
Add a `default` entry to `darwinModules`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       inherit self brew-src;
     };
   in {
-    darwinModules = {
+    darwinModules = rec {
       nix-homebrew = { lib, ... }: {
         imports = [
           ./modules
@@ -26,6 +26,8 @@
           version = brewVersion;
         });
       };
+
+      default = nix-homebrew;
     };
 
     inherit (ci) packages devShell ciTests githubActions;


### PR DESCRIPTION
It just points to the existing `nix-homebrew` module :)

The reasoning for this is that in my config I walk through the flake's inputs and automagically add `{darwin,nixos}Modules.default` to my system's modules. `nix-homebrew` is the odd one out that doesn't include a `default` entry, so I have to import it manually. Not anymore tho, hopefully.