### PR TITLE
update homebrew to version 4.6.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1753461463,
-        "narHash": "sha256-kGc7pRH0diLzKmOHsEFA8sZ9NJpgT+tqxAMsuqNd5Po=",
+        "lastModified": 1756059815,
+        "narHash": "sha256-UALOxoXoFIHbwKzcqbqCAqw5cC0MJEehLaWSet5vxfE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "4d14be89e99a45181c18e96a5f19a5b43343cc0f",
+        "rev": "02947ea4edbdef5fcce9ee57fa289547f4d096c9",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.5.13",
+        "ref": "4.6.7",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/4.5.13";
+      url = "github:Homebrew/brew/4.6.7";
       flake = false;
     };
   };

--- a/modules/brew.tail.sh
+++ b/modules/brew.tail.sh
@@ -6,13 +6,6 @@
 # nix-homebrew:
 # Run scripts/update-brew-tail.sh to update this
 
-# Use HOMEBREW_BREW_WRAPPER if set.
-export HOMEBREW_ORIGINAL_BREW_FILE="${HOMEBREW_BREW_FILE}"
-if [[ -n "${HOMEBREW_BREW_WRAPPER:-}" ]]
-then
-  HOMEBREW_BREW_FILE="${HOMEBREW_BREW_WRAPPER}"
-fi
-
 # These variables are exported in this file and are not allowed to be overridden by the user.
 BIN_BREW_EXPORTED_VARS=(
   HOMEBREW_BREW_FILE
@@ -31,8 +24,8 @@ export_homebrew_env_file() {
   [[ -r "${env_file}" ]] || return 0
   while read -r line
   do
-    # only load HOMEBREW_* lines
-    [[ "${line}" = "HOMEBREW_"* ]] || continue
+    # only load variables defined in env_config.rb
+    [[ "${line}" =~ ^(HOMEBREW_|SUDO_ASKPASS=|(all|no|ftp|https?)_proxy=) ]] || continue
 
     # forbid overriding variables that are set in this file
     local invalid_variable
@@ -45,6 +38,9 @@ export_homebrew_env_file() {
     export "${line?}"
   done <"${env_file}"
 }
+
+# We only want to be able to set this in `brew.env` files.
+unset HOMEBREW_DISABLE_NO_FORCE_BREW_WRAPPER
 
 # First, load the system-wide configuration.
 export_homebrew_env_file "/etc/homebrew/brew.env"
@@ -72,6 +68,13 @@ export_homebrew_env_file "${HOMEBREW_USER_CONFIG_HOME}/brew.env"
 if [[ -n "${SYSTEM_ENV_TAKES_PRIORITY-}" ]]
 then
   export_homebrew_env_file "/etc/homebrew/brew.env"
+fi
+
+# Use HOMEBREW_FORCE_BREW_WRAPPER if set.
+export HOMEBREW_ORIGINAL_BREW_FILE="${HOMEBREW_BREW_FILE}"
+if [[ -n "${HOMEBREW_FORCE_BREW_WRAPPER:-}" ]]
+then
+  HOMEBREW_BREW_FILE="${HOMEBREW_FORCE_BREW_WRAPPER}"
 fi
 
 # Copy and export all HOMEBREW_* variables previously mentioned in


### PR DESCRIPTION
Updates the version to 4.6.7

Otherwise the following problem occurs (e.g. by installing log-options+):

```
Error: Unexpected method 'rename' called on Cask logi-options+.
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs
```