### PR TITLE
module: propagate `brew shellenv` on non-interactive shells too

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -496,11 +496,11 @@ in {
       eval "$(brew shellenv 2>/dev/null || true)"
     '';
 
-    programs.zsh.interactiveShellInit = lib.mkIf cfg.enableZshIntegration ''
+    programs.zsh.shellInit = lib.mkIf cfg.enableZshIntegration ''
       eval "$(brew shellenv 2>/dev/null || true)"
     '';
 
-    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+    programs.fish.shellInit = lib.mkIf cfg.enableFishIntegration ''
       brew shellenv 2>/dev/null | source || true
     '';
 


### PR DESCRIPTION
I have my terminal emulator configured to launch nushell through `zsh -c nu`. The reasoning is that nix doesn't have first-class suport for nushell (i.e: `programs.nushell.enable`) so all the env vars like `PATH` aren't properly set. Launching it through one of the supported shells (`zsh` in this case) fixes the issue, but because the shell is not being launched interactively, because of the `-c` option, the brew envs weren't being properly propagated, because the code used to place the shell integration in `interactiveShellInit`. This patch just places the integration in `shellInit` instead, which fixes my issue and I think makes overall more sense.

The exception is bash, which only has `interactiveShellInit` because it doesn't have the notion of multiple different config files that get loaded depending on how the shell is launched AFAICT - but I'm not a bash user.
