### PR TITLE
.github: Switch to samueldr/lix-gha-installer-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v17
+      - uses: samueldr/lix-gha-installer-action@v2025-10-27
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
@@ -26,7 +26,7 @@ jobs:
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v17
+      - uses: samueldr/lix-gha-installer-action@v2025-10-27
 
       - name: Set up /run for nix-darwin
         run: |


### PR DESCRIPTION
The installer was installing dnixd despite the repo pinning `DeterminateSystems/nix-installer-action@v17` with `determinate: false` set by default.