### PR TITLE
Update brew to version 5.0.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1763638478,
-        "narHash": "sha256-n/IMowE9S23ovmTkKX7KhxXC2Yq41EAVFR2FBIXPcT8=",
+        "lastModified": 1769363988,
+        "narHash": "sha256-BiGPeulrDVetXP+tjxhMcGLUROZAtZIhU5m4MqawCfM=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "fbfdbaba008189499958a7aeb1e2c36ab10c067d",
+        "rev": "d01011cac6d72032c75fd2cd9489909e95d9faf2",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.0.3",
+        "ref": "5.0.12",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/5.0.3";
+      url = "github:Homebrew/brew/5.0.12";
       flake = false;
     };
   };


### PR DESCRIPTION
I ran into this issue. This feature was added in [5.0.7](https://github.com/Homebrew/brew/releases/tag/5.0.7)

I bumped the homebrew-src to 5.0.7 on my fork; the installation passed.

```
Installing adobe-digital-editions
Warning: Cask 'adobe-digital-editions' is unreadable: unknown keyword: :user_agent
Error: Cask 'adobe-digital-editions' is unreadable: unknown keyword: :user_agent
==> Searching for similarly named casks...
Installing adobe-digital-editions has failed!
```