### PR TITLE
chore(deps): automate brew-src updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,81 @@
+version: 2
+
+updates:
+  # User-facing flake.
+  # Keep Homebrew as fresh as possible while separating higher-risk major bumps.
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "05:10"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "nix"
+      include: "scope"
+    allow:
+      - dependency-name: "brew-src"
+    groups:
+      brew-src-major:
+        patterns:
+          - "brew-src"
+        update-types:
+          - "major"
+      brew-src-minor-patch:
+        patterns:
+          - "brew-src"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # CI/dev-only flake.
+  # Keep these grouped by purpose instead of assuming SemVer for branch/commit inputs.
+  - package-ecosystem: "nix"
+    directory: "/ci"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:20"
+      timezone: "UTC"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      ci-flake-inputs:
+        patterns:
+          - "*"
+
+  # GitHub Actions used by .github/workflows/*.y[a]ml.
+  # Keep SemVer major updates separate from minor/patch updates.
+  # Date-tagged or otherwise non-SemVer actions are grouped separately.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions-major:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "samueldr/lix-gha-installer-action"
+        update-types:
+          - "major"
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "samueldr/lix-gha-installer-action"
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-non-semver:
+        patterns:
+          - "samueldr/lix-gha-installer-action"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,77 @@
+version: 2
+
+updates:
+  # User-facing flake.
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "05:10"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "nix"
+      include: "scope"
+    allow:
+      - dependency-name: "brew-src"
+    groups:
+      brew-src-major:
+        patterns:
+          - "brew-src"
+        update-types:
+          - "major"
+      brew-src-minor-patch:
+        patterns:
+          - "brew-src"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # CI/dev-only flake.
+  - package-ecosystem: "nix"
+    directory: "/ci"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:20"
+      timezone: "UTC"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      ci-flake-inputs:
+        patterns:
+          - "*"
+
+  # GitHub Actions used by .github/workflows/*.y[a]ml.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions-major:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "samueldr/lix-gha-installer-action"
+        update-types:
+          - "major"
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "samueldr/lix-gha-installer-action"
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-non-semver:
+        patterns:
+          - "samueldr/lix-gha-installer-action"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
       - uses: samueldr/lix-gha-installer-action@v2025-10-27
       - id: set-matrix
         name: Generate Nix Matrix
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.3.1
       - uses: samueldr/lix-gha-installer-action@v2025-10-27
 
       - name: Set up /run for nix-darwin


### PR DESCRIPTION
## Summary

This adds a Dependabot configuration for `brew-src`, the CI flake, and GitHub Actions dependencies.

The goal is to reduce the manual work needed to keep `brew-src` close to upstream Homebrew releases.

## Changes

- Check the root flake daily for `brew-src` updates.
- Separate `brew-src` major updates from minor/patch updates.
- Check the CI flake weekly and group its inputs into one PR.
- Check GitHub Actions weekly.
- Separate GitHub Actions major updates from minor/patch updates.
- Exclude the date-tagged `samueldr/lix-gha-installer-action` from SemVer-based GitHub Actions groups.
- Pin `actions/checkout` to an explicit v4 patch release so Dependabot can propose future patch/minor/major updates as normal version bumps instead of leaving the workflow on the moving `v4` tag.

## Context

Recent `brew-src` updates, such as #141, #142, #143 and #147, have been handled manually. This PR uses Dependabot's built-in Nix and GitHub Actions support as a lightweight alternative or complement to #121.

## Testing

Tested in my fork. After merging the test PR and running Dependabot, it opened the expected dependency update PRs for `brew-src`, the CI flake inputs, and GitHub Actions.

The current open Dependabot PRs from that test run are visible here (filtered by the `dependencies` label that Dependabot applies to its PRs): https://github.com/ottnorml/zhaofengli_nix-homebrew/pulls?q=is%3Aopen+is%3Apr+label%3Adependencies

This includes a `brew-src` major update PR for Homebrew 6.0.0, showing that the `brew-src` major-update path is handled separately from minor/patch updates.

It also opened grouped PRs for the CI flake inputs and GitHub Actions updates. So if this PR is merged as-is, I would expect a small initial set of Dependabot PRs for currently outdated dependencies. After that, it should settle into the configured update schedule.

As expected, no update PR was opened for `samueldr/lix-gha-installer-action@v2025-10-27`, because it uses a date-style tag. I kept it out of the SemVer-based GitHub Actions groups; updating that action can be handled separately.

## Possible follow-ups

Auto-merge for low-risk Dependabot PRs could be considered later, once this update flow has proven useful. This PR intentionally leaves review and merging to maintainers.