### PR TITLE
brew-src: 5.1.11 -> 5.1.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778427648,
-        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
+        "lastModified": 1779117401,
+        "narHash": "sha256-3Tc6sFio1LDzr24PsJrZn6jwchLgRWIIqv/wB0ZbOuM=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
+        "rev": "c3542bb62f44e4b12e7a30845a8c1e62e230ef12",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.11",
+        "ref": "5.1.12",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/5.1.11";
+      url = "github:Homebrew/brew/5.1.12";
       flake = false;
     };
   };


### PR DESCRIPTION
https://github.com/Homebrew/brew/releases/tag/5.1.12

even after `5.1.11` I got some issues with `depends_on`, but after `5.1.12` I updated without problem