### PR TITLE
chore(deps): upgrade brew-src to 5.1.15

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779646357,
-        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
+        "lastModified": 1780483234,
+        "narHash": "sha256-jgt0wi5Jf2QxzLOzB6T95mRyZeWJNAbG2GpLNjvAiwc=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
+        "rev": "863696a47f8d9292cb25084b6f8228e003084101",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.14",
+        "ref": "5.1.15",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/5.1.14";
+      url = "github:Homebrew/brew/5.1.15";
       flake = false;
     };
   };


### PR DESCRIPTION
Bumps the pinned Homebrew/brew from 5.1.14 to 5.1.15.

Fixes Warning: 'gdk-pixbuf' formula is unreadable: undefined local variable or method 'gdk_pixbuf_query_loaders' ... (and the same warning for 'librsvg'). The `gdk_pixbuf_query_loaders` install-step DSL method was added in Homebrew/brew 5.1.15.


Related PR: https://github.com/Homebrew/brew/pull/22513