### PR TITLE
brew-src: 5.1.14 -> 6.0.1

### DIFF
--- a/ci/flake.nix
+++ b/ci/flake.nix
@@ -112,7 +112,7 @@
             pkgs:
             pkgs.mkShell {
               nativeBuildInputs = with pkgs; [
-                nixfmt-rfc-style
+                nixfmt
               ];
 
               BREW_SRC = brew-src;

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779646357,
-        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.14",
+        "ref": "6.0.1",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/5.1.14";
+      url = "github:Homebrew/brew/6.0.1";
       flake = false;
     };
   };

--- a/pkgs/nuke-homebrew-repository/nuke-homebrew-repository.sh.in
+++ b/pkgs/nuke-homebrew-repository/nuke-homebrew-repository.sh.in
@@ -30,7 +30,7 @@ if [[ ! -e ".git" ]]; then
   exit 1
 fi
 
-if ! grep -E "^# Homebrew" "README.md" >/dev/null; then
+if ! grep -E "^#.*Homebrew" "README.md" >/dev/null; then
   >&2 echo "${PWD} does not looks like a Homebrew checkout"
   exit 1
 fi


### PR DESCRIPTION
Changelog: https://github.com/Homebrew/brew/compare/5.1.14...6.0.1

This release includes [preliminary support](https://github.com/Homebrew/brew/pull/22592) for macOS 27 Golden Gate.