### PR TITLE
Add support for adding trust entries during activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ If you haven't installed Homebrew before, use the following configuration:
             #
             # With mutableTaps disabled, taps can no longer be added imperatively with `brew tap`.
             mutableTaps = false;
+
+            # Optional: Declarative Homebrew tap trust entries.
+            #
+            # Note: The trust entries are _not_ removed if you remove them from those lists!
+            # Use the `brew untrust` command to remove a trust entry.
+            trust = {
+              formulae = [ ];
+              casks = [ ];
+              commands = [ ];
+              taps = [ ];
+            };
           };
         }
         # Optional: Align homebrew taps config with nix-homebrew
@@ -82,6 +93,25 @@ Run `arch -x86_64 brew` to install X86-64 packages through Rosetta 2.
 With `nix-homebrew.mutableTaps = false`, taps can be removed by deleting the corresponding attribute in `nix-homebrew.taps` and activating the new configuration.
 
 Setting `homebrew.taps` to equal `nix-homebrew.taps` attribute names reduces configuration mismatches. 
+
+For non-official taps, Homebrew requires [explicit trust](https://docs.brew.sh/Tap-Trust).
+You may use imperative `brew trust`/`brew untrust` commands, or configure `nix-homebrew` to add trust entries during activation:
+
+```nix
+nix-homebrew.trust = {
+  formulae = [ "user/repo/formula" ];
+  casks = [ "user/repo/cask" ];
+  commands = [ "user/repo/command" ];
+
+  # To quote upstream documentation:
+  # > Trust a whole tap only when you are comfortable with all current and
+  # > future formulae, casks and external commands from that tap being loaded
+  # > by Homebrew.
+  taps = [ "user/repo" ];
+};
+```
+Note that when you remove items from those lists, the corresponding trust entries are _not_ removed automatically.
+Use the `brew untrust` command to remove a trust entry.
 
 ### B. Existing Homebrew Installation
 

--- a/ci/tests.nix
+++ b/ci/tests.nix
@@ -83,6 +83,12 @@ let
           mkdir -p "$out/Casks/u"
           touch "$out/Casks/u/ungoogled-chromium.rb"
         '';
+        fakeThirdPartyTap = pkgs.runCommandLocal "thirdparty-test-tap" { } ''
+          mkdir -p "$out/Formula" "$out/Casks" "$out/cmd"
+          touch "$out/Formula/foo.rb"
+          touch "$out/Casks/test-cask.rb"
+          touch "$out/cmd/brew-test-command.rb"
+        '';
       in
       {
         imports = [
@@ -96,6 +102,12 @@ let
           autoMigrate = true;
           taps = {
             "homebrew/homebrew-cask" = fakeCaskTap;
+            "thirdparty/homebrew-testtap" = fakeThirdPartyTap;
+          };
+          trust = {
+            formulae = [ "thirdparty/testtap/foo" ];
+            casks = [ "thirdparty/testtap/test-cask" ];
+            commands = [ "thirdparty/testtap/test-command" ];
           };
         };
 
@@ -112,6 +124,15 @@ let
           cask_path="$tap_root/homebrew/homebrew-cask/Casks/u/ungoogled-chromium.rb"
 
           test -f "$cask_path"
+
+          >&2 echo "Checking declarative Homebrew trust entries"
+          brew trust --json=v1 --formula | grep '"thirdparty/testtap/foo"'
+          brew trust --json=v1 --cask | grep '"thirdparty/testtap/test-cask"'
+          brew trust --json=v1 --command | grep '"thirdparty/testtap/test-command"'
+          if brew trust --json=v1 --tap | grep '"thirdparty/testtap"'; then
+            >&2 echo "Expected thirdparty/testtap not to be trusted as a whole tap"
+            exit 1
+          fi
 
           tap_root_real="$(${pkgs.coreutils}/bin/realpath "$tap_root")"
           cask_real="$(${pkgs.coreutils}/bin/realpath "$cask_path")"

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -252,6 +252,19 @@ let
       exit 1
     fi
     /bin/ln -shf "${makeBinBrew prefix}" "$BIN_BREW"
+
+    ${setupTrust}
+  '';
+
+  setupTrust = let
+    trustEntries = flag: entries: lib.concatMapStrings (entry: ''
+      /usr/bin/sudo -n -u ${lib.escapeShellArg cfg.user} -H "$BIN_BREW" trust ${flag} ${lib.escapeShellArg entry} >/dev/null
+    '') entries;
+  in ''
+    ${trustEntries "--tap" cfg.trust.taps}
+    ${trustEntries "--formula" cfg.trust.formulae}
+    ${trustEntries "--cask" cfg.trust.casks}
+    ${trustEntries "--command" cfg.trust.commands}
   '';
 
   setupTaps = taps:
@@ -389,6 +402,68 @@ in {
         '';
         type = types.bool;
         default = true;
+      };
+      trust = lib.mkOption {
+        description = ''
+          Tap trust entries to be added during activation.
+
+          Note: The trust entries are _not_ removed if you remove them from
+          those lists! Use the `brew untrust` command to remove a trust entry.
+
+          Refer to upstream documentations for more information:
+          <https://docs.brew.sh/Tap-Trust>
+        '';
+        type = types.submodule {
+          options = {
+            taps = lib.mkOption {
+              description = ''
+                Taps to trust in their entirety.
+
+                This should be used with caution. To quote upstream documentation:
+
+                > Trust a whole tap only when you are comfortable with all current and
+                > future formulae, casks and external commands from that tap being loaded
+                > by Homebrew.
+              '';
+              type = types.listOf types.str;
+              default = [];
+              example = [
+                "user/repo"
+              ];
+            };
+            formulae = lib.mkOption {
+              description = ''
+                Fully-qualified formulae to trust.
+              '';
+              type = types.listOf types.str;
+              default = [];
+              example = [
+                "user/repo/formula"
+              ];
+            };
+            casks = lib.mkOption {
+              description = ''
+                Fully-qualified casks to trust.
+              '';
+              type = types.listOf types.str;
+              default = [];
+              example = [
+                "user/repo/cask"
+              ];
+            };
+            commands = lib.mkOption {
+              description = ''
+                Fully-qualified external commands to trust.
+              '';
+              type = types.listOf types.str;
+              default = [];
+              example = [
+                "user/repo/command"
+              ];
+            };
+          };
+        };
+        default = {};
       };
       autoMigrate = lib.mkOption {
         description = ''


### PR DESCRIPTION
Homebrew 6.0 has introduced the [tap trust](https://docs.brew.sh/Tap-Trust) mechanism and all non-official taps are untrusted by default. Right now, you need to run imperative `brew trust` commands for third-party taps. This PR adds an option to add trust entries automatically during activation.

Instead of trusting whole taps automatically, here we let the user configure what to trust. I think this implementation better aligns with upstream intent.

Fixes #156.

## Example

```nix
  nix-homebrew = {
    # ...
    trust = {
      formulae = [
        "koekeishiya/homebrew-formulae/yabai"
      ];
    };
  };
```

```console
$ brew trust
All official taps and commands are trusted.
Trusted formulae:
  koekeishiya/formulae/yabai
```