### PR TITLE
brew-src: 6.0.1 -> 6.0.9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1781226006,
-        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
+        "lastModified": 1783298955,
+        "narHash": "sha256-02tX5z0qf+SX+VfqwnyVtvfwq710mtDzh+Rg2Dn73vU=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
+        "rev": "20ce57618d82c7a29801deb1f0f2bc665ed9b55e",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.1",
+        "ref": "6.0.7",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1783298955,
-        "narHash": "sha256-02tX5z0qf+SX+VfqwnyVtvfwq710mtDzh+Rg2Dn73vU=",
+        "lastModified": 1783446865,
+        "narHash": "sha256-nCrPEbQjgnSAOVWTxRXD9Yi6P3oECdtZISYcQCFI9Fs=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "20ce57618d82c7a29801deb1f0f2bc665ed9b55e",
+        "rev": "655769712a9a9499563d9685a8488f349354492d",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.7",
+        "ref": "6.0.9",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/6.0.7";
+      url = "github:Homebrew/brew/6.0.9";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/6.0.1";
+      url = "github:Homebrew/brew/6.0.7";
       flake = false;
     };
   };


### PR DESCRIPTION
Bumps the pinned Homebrew/brew version from `6.0.1` to the latest stable release `6.0.9`.

## Motivation

`6.0.7` includes [Homebrew/brew#22961](https://github.com/Homebrew/brew/pull/22961) ("Add install step data directories", merge commit `78e8b0e374e2`, merged 2026-07-05), which adds the `init_data_dir` InstallSteps DSL action.

Without this, homebrew-core's current `postgresql@18` formula fails to install with:

```
undefined method 'init_data_dir' for an instance of Homebrew::InstallSteps::DSL
```

`6.0.7` is the newest stable release that includes the fix — `6.0.6` (2026-06-30) predates the merge (verified via `gh api repos/Homebrew/brew/compare/78e8b0e374e2...<tag>`: `6.0.7` is `ahead`, `6.0.6` is `behind`).



Beyond the postgresql@18 init_data_dir issue, the 6.0.1 pin also causes formula readability errors for any formula using the type patch DSL (added in 4ead861, shipped in 6.0.7):

 ```
   Warning: 'openssl@3' formula is unreadable: homebrew/core/openssl@3: undefined method 'type' for an instance of
 Resource::Patch
   Warning: 'c-blosc' formula is unreadable: homebrew/core/c-blosc: undefined method 'type' for an instance of
 Resource::Patch
   Warning: 'podman' formula is unreadable: homebrew/core/podman: undefined method 'type' for an instance of Resource::Patch
 ```

This breaks brew bundle for anyone whose Brewfile transitively depends on these formulae (e.g. pnpm, mise both failed to upgrade because openssl@3 couldn't be loaded).

The type and resolves DSL methods were added to Resource::Patch in patch.rb/resource.rb as part of Homebrew/brew#22466 (patch annotation for CycloneDX SBOM pedigree). Confirmed that bumping to 6.0.9 resolves all three warnings and brew bundle completes cleanly.