### PR TITLE
brew-src: 6.0.12 -> 6.0.13

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784558651,
-        "narHash": "sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI=",
+        "lastModified": 1785146564,
+        "narHash": "sha256-Sa7/HrfB04H32OJ7/ofxXjiZEbkWtCNOriONYYTL1OA=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "b48c7994b5f0eed7bef532efa63cb4e4f763887a",
+        "rev": "b2cfc03346d482f79886de108fee5dc49a6efc10",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.12",
+        "ref": "6.0.13",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/6.0.12";
+      url = "github:Homebrew/brew/6.0.13";
       flake = false;
     };
   };


### PR DESCRIPTION
Fixes #163. Follow-up to #162, which bumped brew for the same reason.

Formulae and casks in `homebrew/core` and `homebrew/cask` now use DSL methods that only exist in brew 6.0.13, so pinning 6.0.12 makes them unreadable:

```
Warning: 'ca-certificates' formula is unreadable: homebrew/core/ca-certificates: undefined method 'run' for an instance of Homebrew::InstallSteps::DSL
Error: Cask 'zoom' definition is invalid: undefined method 'terminate_process' for an instance of Homebrew::InstallSteps::DSL
Error: Cask 'firefox' definition is invalid: undefined method 'command_wrapper' for Cask 'firefox'
```

Comparing the two source trees confirms each missing method is added in 6.0.13:

| Method | 6.0.12 | 6.0.13 |
| --- | --- | --- |
| `run` on `InstallSteps::DSL` | only the unrelated `run(steps, phase:)` runner | `run(command, args:, base:, env:, sudo:, …)` at `install_steps.rb:557` (Homebrew/brew#23186) |
| `terminate_process` | absent | `install_steps.rb:582` (Homebrew/brew#23187) |
| `command_wrapper` | absent | `cask/artifact/command_wrapper.rb`, required from `cask/artifact.rb` (Homebrew/brew#23183) |

This covers both errors reported in #163 (`command_wrapper` for `firefox`/`kate`/`betterdisplay`, and `run` for `orbstack`); pinning `brew-src` to 6.0.13 was independently confirmed as a workaround there.

Lock regenerated with `nix flake update brew-src`.
