### PR TITLE
brew-src: 6.0.13 -> 6.0.15

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1785146564,
-        "narHash": "sha256-Sa7/HrfB04H32OJ7/ofxXjiZEbkWtCNOriONYYTL1OA=",
+        "lastModified": 1785710351,
+        "narHash": "sha256-DTL5T9+HlblsnXCEdxRpEo/2NBHD3t48BS7r+PTf090=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "b2cfc03346d482f79886de108fee5dc49a6efc10",
+        "rev": "7b0f22a4ab77567edef114c8dfc423fb96e2fbaa",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.13",
+        "ref": "6.0.15",
         "repo": "brew",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     brew-src = {
-      url = "github:Homebrew/brew/6.0.13";
+      url = "github:Homebrew/brew/6.0.15";
       flake = false;
     };
   };


### PR DESCRIPTION
Follow-up to #162 and #164, which bumped brew for the same reason: formulae in `homebrew/core` now use install-step DSL methods that only exist in a newer brew, so an older pin makes them unreadable.

`homebrew/core/llvm` uses `configure_clang_system`, which does not exist in 6.0.13:

```
==> Upgrading 1 outdated package:
gdal 3.13.2 -> 3.13.2_1
Error: homebrew/core/llvm: undefined local variable or method 'configure_clang_system' for an instance of Homebrew::InstallSteps::DSL
Upgrading gdal has failed!
```

Anything depending on `llvm` (here, `gdal`) fails before the upgrade starts. Comparing the source trees confirms the method arrives in 6.0.14:

| Symbol | 6.0.13 | 6.0.15 |
| --- | --- | --- |
| `configure_clang_system` on `InstallSteps::DSL` | absent | `Library/Homebrew/install_steps.rb:751` |
| `run_configure_clang_system` | absent | `Library/Homebrew/install_steps/formula_actions.rb:120` |
| `Library/Homebrew/utils/clang.rb` | file absent | present |

Added by Homebrew/brew#23190 (merged 2026-07-29), released in 6.0.14.

Supersedes #165, which bumps to 6.0.14 and would also resolve this; this goes to 6.0.15, the current release. Release notes: [6.0.14](https://github.com/Homebrew/brew/releases/tag/6.0.14), [6.0.15](https://github.com/Homebrew/brew/releases/tag/6.0.15).

Lock regenerated with `nix flake update brew-src`.
