### PR TITLE
ci: stop pairing nixpkgs unstable with x86_64-darwin

### DIFF
--- a/ci/flake.nix
+++ b/ci/flake.nix
@@ -67,8 +67,15 @@
           lib.listToAttrs
         ];
 
-      forAllSystems =
-        f: lib.genAttrs supportedSystems (system: f inputs.nixpkgs_unstable.legacyPackages.${system});
+      # Unstable doesn't cover every supported system anymore.
+      pkgsFor =
+        system:
+        if lib.elem system releases.unstable.systems then
+          inputs.nixpkgs_unstable.legacyPackages.${system}
+        else
+          inputs.nixpkgs_26_05.legacyPackages.${system};
+
+      forAllSystems = f: lib.genAttrs supportedSystems (system: f (pkgsFor system));
 
       makeCi =
         { self, brew-src }:

--- a/ci/flake.nix
+++ b/ci/flake.nix
@@ -21,21 +21,24 @@
     let
       inherit (inputs.nixpkgs_unstable) lib;
 
-      supportedSystems = [
-        "x86_64-darwin"
-        "aarch64-darwin"
-      ];
-
       releases = {
         "unstable" = {
           nixpkgs = inputs.nixpkgs_unstable;
           nix-darwin = inputs.nix-darwin_unstable;
+          # Nixpkgs 26.11 dropped x86_64-darwin; evaluating it is a hard error.
+          systems = [ "aarch64-darwin" ];
         };
         "26.05" = {
           nixpkgs = inputs.nixpkgs_26_05;
           nix-darwin = inputs.nix-darwin_26_05;
+          systems = [
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
         };
       };
+
+      supportedSystems = lib.unique (lib.concatMap (release: release.systems) (lib.attrValues releases));
 
       githubPlatforms = {
         "aarch64-darwin" = "macos-26";
@@ -94,7 +97,7 @@
               assembleTest {
                 inherit system release test;
               }
-            ) matrix
+            ) (lib.filterAttrs (name: setup: lib.elem system releases.${setup.release}.systems) matrix)
           );
           ciScripts = lib.mapAttrs (
             system: tests: lib.mapAttrs (name: test: test.config.system.build.ci-script) tests


### PR DESCRIPTION
Nixpkgs 26.11 dropped x86_64-darwin, which is why #169 fails: every
`*-unstable (x86_64-darwin)` job errors out. It's an evaluation error rather
than a build failure, so it also takes out `packages.x86_64-darwin` and
`devShell.x86_64-darwin`, which the root flake re-exports.

Each release now declares which systems it covers. Unstable is aarch64 only;
26.05 keeps both and is supported until the end of 2026, which is as long as
x86_64-darwin coverage can last anyway. `forAllSystems` picks the newest
release that still supports a given system instead of always using unstable.

Matrix goes from 16 jobs to 12.

Tested on my fork with #169's `ci/flake.lock` applied: the matrix evaluates,
12 jobs, no unstable x86_64 entries, and packages and devShell evaluate on
both systems. Green run: https://github.com/Azd325/nix-homebrew/pull/1

#169 should go green once it rebases on this.
