### PR TITLE
ci: workflow hardening

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   nix-matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -25,6 +26,7 @@ jobs:
     name: ${{ matrix.name }} (${{ matrix.system }})
     needs: nix-matrix
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   nix-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nix-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
     needs: nix-matrix
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4.3.1


### PR DESCRIPTION
Five small changes to `.github/workflows/ci.yaml`, one per commit.

`on: push` had no branch filter, so any branch pushed to this repo ran the
matrix twice, once for the push and once for the PR. 12 commits in the last
100 runs have both. Fork PRs were never affected, which is why it stayed
invisible until Dependabot started opening branches here.

`fail-fast` defaulted to true. On #169 one failing job cancelled nine
siblings, so the run reported one real failure and nine unknowns.

The rest: `contents: read` on the token, `timeout-minutes` on both jobs (the
default is 360, and the slowest successful job in the last 166 was 8.2
minutes), and a concurrency group so superseded PR runs stop instead of
holding a macOS runner to the end.

The concurrency group is keyed on `head_ref` rather than `github.ref` on
purpose. A group holds at most one running and one pending run, so grouping
every push to main together drops intermediate commits. I ran into that on my
fork before switching to `head_ref || run_id`.

Green on my fork: https://github.com/Azd325/nix-homebrew/pull/3
